### PR TITLE
handle all valid characters in queries

### DIFF
--- a/pegasus/request.lua
+++ b/pegasus/request.lua
@@ -45,7 +45,7 @@ function Request:parseFirstLine()
   self._method = method
 end
 
-Request.PATTERN_QUERY_STRING = '(%w+)=(%w+)'
+Request.PATTERN_QUERY_STRING = '([^=]*)=([^&]*)&?'
 
 function Request:parseURLEncoded(value, _table)
   --value exists and _table is empty


### PR DESCRIPTION
Pegasus should be able to handle all query patterns in POST requests. Change the query pattern to allow just that.