### PR TITLE
Solve the issue about Header Authorization, error in Basic scheme.

### DIFF
--- a/pegasus/request.lua
+++ b/pegasus/request.lua
@@ -79,7 +79,7 @@ function Request:method()
   return self._method
 end
 
-Request.PATTERN_HEADER = '([%w-]+): ([%w-=]+)'
+Request.PATTERN_HEADER = '([%w-]+): ([%w %w]+)'
 
 function Request:headers()
   if self._headers_parsed then


### PR DESCRIPTION
This Pull request is proposal to solve the issue about Header Authorization, error in Basic scheme.

More details below.


#### Pattern version v0.0.4

Request.PATTERN_HEADER = '([%w-]+): ([%w-=]+)'


##### Example:

```lua
Header = "Authorization: Basic YWRtaW46YWRtaW4="
	
Request.PATTERN_HEADER = '([%w-]+): ([%w-=]+)'

header, scheme = string.match(Header, PATTERN_HEADER)

print(header, scheme)
```	

**Output**

	# Authorization	Basic


### Proposal for a new Pattern

Request.PATTERN_HEADER = '([%w-]+): ([%w %w]+)'

##### Example:

```lua
Header = "Authorization: Basic YWRtaW46YWRtaW4="

Request.PATTERN_HEADER = '([%w-]+): ([%w %w]+)'

header, scheme = string.match(Header, PATTERN_HEADER)

print(header, scheme)
```

**Output**

	# Authorization	Basic YWRtaW46YWRtaW4
	


Now it's possible implement basic auth according  RFC 2617 :smile: