### PR TITLE
Add caracter '=' in Request.PATTERN_HEADER

### DIFF
--- a/src/pegasus/request.lua
+++ b/src/pegasus/request.lua
@@ -81,7 +81,7 @@ function Request:method()
   return self._method
 end
 
-Request.PATTERN_HEADER = '([%w-]+): ([%w %w]+)'
+Request.PATTERN_HEADER = '([%w-]+): ([%w %w]+=)'
 
 function Request:headers()
   if self._headers_parsed then


### PR DESCRIPTION
Fixed according RFC 2617, I forgot this at the last pull request. sorry.

Now is compatible with [basic-auth](https://github.com/jairojair/basic-auth) :v: 