### PR TITLE
Self-managable server loop

### DIFF
--- a/src/pegasus/init.lua
+++ b/src/pegasus/init.lua
@@ -3,7 +3,7 @@ local Handler = require 'pegasus.handler'
 
 local Pegasus = {}
 
-Pegasus.__index = self
+Pegasus.__index = Pegasus
 
 function Pegasus:new(params)
   params = params or {}

--- a/src/pegasus/init.lua
+++ b/src/pegasus/init.lua
@@ -26,8 +26,10 @@ end
 
 function Pegasus:iterate()
   local client = self.server:accept()
-  client:settimeout(1, 'b')
-  self.handler:processRequest(client)
+  if client then
+     client:settimeout(1, 'b')
+     self.handler:processRequest(client)
+  end
 end
 
 function Pegasus:start(callback, talk)

--- a/src/pegasus/init.lua
+++ b/src/pegasus/init.lua
@@ -17,17 +17,25 @@ function Pegasus:new(params)
   return setmetatable(server, self)
 end
 
-function Pegasus:start(callback)
-  local handler = Handler:new(callback, self.location, self.plugins)
-  local server = assert(socket.bind('*', self.port))
-  local ip, port = server:getsockname()
-  print('Pegasus is up on ' .. ip .. ":".. port)
-
-  while 1 do
-    local client = server:accept()
-    client:settimeout(1, 'b')
-    handler:processRequest(client)
+function Pegasus:prepare(callback, talk)
+  self.handler = Handler:new(callback, self.location, self.plugins)
+  self.server = assert(socket.bind('*', self.port))
+  local ip, port = self.server:getsockname()
+  if talk == nil or talk then
+     print('Pegasus is up on http://' .. ip .. ":".. port)
   end
+end
+
+function Pegasus:iterate()
+  local client = self.server:accept()
+  client:settimeout(1, 'b')
+  self.handler:processRequest(client)
+end
+
+function Pegasus:start(callback, talk)
+  self:prepare(callback, talk)
+
+  while 1 do self:iterate() end
 end
 
 return Pegasus

--- a/src/pegasus/init.lua
+++ b/src/pegasus/init.lua
@@ -1,13 +1,13 @@
 local socket = require 'socket'
 local Handler = require 'pegasus.handler'
 
-
 local Pegasus = {}
+
+Pegasus.__index = self
 
 function Pegasus:new(params)
   params = params or {}
   local server = {}
-  self.__index = self
 
   local port, location
   server.port = params.port or '9090'

--- a/src/pegasus/init.lua
+++ b/src/pegasus/init.lua
@@ -17,12 +17,10 @@ function Pegasus:new(params)
   return setmetatable(server, self)
 end
 
-function Pegasus:prepare(callback, talk)
-  self.handler = Handler:new(callback, self.location, self.plugins)
-  self.server = assert(socket.bind('*', self.port))
-  local ip, port = self.server:getsockname()
-  if talk == nil or talk then
-     print('Pegasus is up on http://' .. ip .. ":".. port)
+function Pegasus:prepare(callback)
+  if not self.server then
+    self.handler = Handler:new(callback, self.location, self.plugins)
+    self.server = assert(socket.bind('*', self.port))
   end
 end
 
@@ -33,9 +31,13 @@ function Pegasus:iterate()
 end
 
 function Pegasus:start(callback, talk)
-  self:prepare(callback, talk)
+  self:prepare(callback)
 
-  while 1 do self:iterate() end
+  if talk == nil or talk then  -- NOTE/TODO: modules can make it https? They redirect?
+    local ip, port = self.server:getsockname()
+    print('Pegasus is up on http://' .. ip .. ":".. port)
+  end
+  while true do self:iterate() end
 end
 
 return Pegasus

--- a/src/pegasus/request.lua
+++ b/src/pegasus/request.lua
@@ -109,24 +109,9 @@ function Request:headers()
 end
 
 function Request:receiveBody(size)
-  size = size or self._content_length
-
-  -- do we have content?
-  if self._content_done >= self._content_length then return false end
-
-  -- fetch in chunks
-  local fetch = math.min(self._content_length-self._content_done, size)
-
-  local data, err, partial = self.client:receive(fetch)
-
-  if err =='timeout' then
-    err = nil
-    data = partial
-  end
-
-  self._content_done = self._content_done + #data
-
-  return data
+   self:headers()
+   local data, _, partial = self.client:receive("*a")
+   return data or partial
 end
 
 return Request


### PR DESCRIPTION
Basically, `pegasus.server` becomes an exposed, allowing people to i.e. put a timeout in there. `:start` becomes separated into `:prepare` and `:iterate` which users can use directly instead.

Dunno if this undermines the simplicity? Afaics seems alright. (Perhaps the naming can be improved)
#57 is corresponding issue.
