### PR TITLE
Send proper 404 error if no file is found

### DIFF
--- a/src/pegasus/handler.lua
+++ b/src/pegasus/handler.lua
@@ -105,8 +105,7 @@ function Handler:processRequest(port, client)
     local filename = '.' .. self.location .. path
 
     if not lfs.attributes(filename) then
-      response:statusCode(404)
-      return
+      response:writeDefaultErrorMessage(404)
     end
 
     stop = self:pluginsProcessFile(request, response, filename)

--- a/src/pegasus/handler.lua
+++ b/src/pegasus/handler.lua
@@ -105,7 +105,7 @@ function Handler:processRequest(port, client)
     local filename = '.' .. self.location .. path
 
     if not lfs.attributes(filename) then
-      response:writeDefaultErrorMessage(404)
+      response:statusCode(404)
     end
 
     stop = self:pluginsProcessFile(request, response, filename)
@@ -122,10 +122,14 @@ function Handler:processRequest(port, client)
   end
 
   if self.callback then
-    response:statusCode(200)
-    response.headers = {}
-    response:addHeader('Content-Type', 'text/html')
+    -- response:statusCode(200)
+    -- response.headers = {}
+    -- response:addHeader('Content-Type', 'text/html')
     self.callback(request, response)
+  end
+
+  if response.status == 404 then
+    response:writeDefaultErrorMessage(404)
   end
 end
 

--- a/src/pegasus/response.lua
+++ b/src/pegasus/response.lua
@@ -139,8 +139,8 @@ end
 
 function Response:writeDefaultErrorMessage(statusCode)
   self:statusCode(statusCode)
-  content = string.gsub(DEFAULT_ERROR_MESSAGE, '{{ STATUS_CODE }}', statusCode)
-  self:write(string.gsub(content, '{{ STATUS_TEXT }}', STATUS_TEXT[statusCode]))
+  local content = string.gsub(DEFAULT_ERROR_MESSAGE, '{{ STATUS_CODE }}', statusCode)
+  self:write(string.gsub(content, '{{ STATUS_TEXT }}', STATUS_TEXT[statusCode]), false)
   return self
 end
 


### PR DESCRIPTION
Regarding issue #70, this patch will use the function `writeDefaultErrorMessage` defined but never used.
The handler is not stopped after that to allow callback method to rewrite for other use.