### PR TITLE
Fix. Use undefined date format string.

### DIFF
--- a/src/pegasus/response.lua
+++ b/src/pegasus/response.lua
@@ -165,7 +165,7 @@ function Response:sendHeaders(stayOpen, body)
     self:addHeader('Content-Length', body:len())
   end
 
-  self:addHeader('Date', os.date('!%a, %d %b %Y %T GMT', os.time()))
+  self:addHeader('Date', os.date('!%a, %d %b %Y %H:%M:%S GMT', os.time()))
 
   if not self.headers['Content-Type'] then
     self:addHeader('Content-Type', 'text/html')


### PR DESCRIPTION
`%T` is not ISO string format. And this string leads to crash on Windows systems.
Also Lua > 5.1 raise error when try use such format string.

I think it may be related with #61