### PR TITLE
Fix. Do not raise error when calls receiveBody and there no content-length

### DIFF
--- a/src/pegasus/request.lua
+++ b/src/pegasus/request.lua
@@ -114,7 +114,7 @@ function Request:receiveBody(size)
   size = size or self._content_length
 
   -- do we have content?
-  if self._content_done >= self._content_length then return false end
+  if (self._content_length == nil) or (self._content_done >= self._content_length) then return false end
 
   -- fetch in chunks
   local fetch = math.min(self._content_length-self._content_done, size)


### PR DESCRIPTION
Not sure is it best fix. 
What about if there chunked body.