### PR TITLE
Fix. Use undefined read file format.

### DIFF
--- a/src/pegasus/file.lua
+++ b/src/pegasus/file.lua
@@ -50,7 +50,7 @@ function File:open(path)
   local file = io.open(filename, 'r')
 
   if file then
-    return file:read('*all')
+    return file:read('*a')
   end
 
   return nil

--- a/src/pegasus/response.lua
+++ b/src/pegasus/response.lua
@@ -199,7 +199,7 @@ end
 function Response:writeFile(file, contentType)
   self:contentType(contentType)
   self:statusCode(200)
-  local value = file:read('*all')
+  local value = file:read('*a')
   self:write(value)
 
   return self


### PR DESCRIPTION
Lua does not define `*all` as format but just `*a`.
And since Lua 5.2 even just `a` but `*` also supported for compatibility.