### PR TITLE
More descriptive crash message

### DIFF
--- a/src/pegasus/init.lua
+++ b/src/pegasus/init.lua
@@ -24,9 +24,13 @@ function Pegasus:start(callback)
   print('Pegasus is up on ' .. ip .. ":".. port)
 
   while 1 do
-    local client = assert(server:accept())
-    client:settimeout(self.timeout, 'b')
-    handler:processRequest(self.port, client, server)
+    local client, errmsg = server:accept()
+    if not client then
+      io.stderr:write("Failed to accept connection:" .. errmsg .. "\n")
+    else
+      client:settimeout(self.timeout, 'b')
+      handler:processRequest(self.port, client, server)
+    end
   end
 end
 

--- a/src/pegasus/init.lua
+++ b/src/pegasus/init.lua
@@ -24,7 +24,7 @@ function Pegasus:start(callback)
   print('Pegasus is up on ' .. ip .. ":".. port)
 
   while 1 do
-    local client = server:accept()
+    local client = assert(server:accept())
     client:settimeout(self.timeout, 'b')
     handler:processRequest(self.port, client, server)
   end


### PR DESCRIPTION
In some cases, server:accept() can fail, when it does it returns
nil + an error message. When it fails, display the error
instead of failing to index nil on the next line.