### PR TITLE
fix(request): don't close server socket

### DIFF
--- a/src/pegasus/request.lua
+++ b/src/pegasus/request.lua
@@ -73,8 +73,6 @@ function Request:parseFirstLine()
 
   if not method then
     self.client:close()
-    self.server:close()
-
     return
   end
 


### PR DESCRIPTION
a request should never close the server socket.

In general I think that the server socket should not be passed at all to the handler. At most some properties.