### PR TITLE
fix(response): close and onlyheaders return self

### DIFF
--- a/src/pegasus/response.lua
+++ b/src/pegasus/response.lua
@@ -141,11 +141,15 @@ function Response:close()
 
   self._client:send('0\r\n\r\n')
   self.close = true
+  
+  return self
 end
 
 function Response:sendOnlyHeaders()
   self:sendHeaders(false, '')
   self:write('\r\n')
+  
+  return self
 end
 
 function Response:sendHeaders(stayOpen, body)


### PR DESCRIPTION
To make the methods inline with the rest.