### PR TITLE
fix(rockspecs) add missing, add dev, add updated 0.9.7

### DIFF
--- a/rockspecs/pegasus-0.9.7-0.rockspec
+++ b/rockspecs/pegasus-0.9.7-0.rockspec
@@ -1,0 +1,33 @@
+package = 'pegasus'
+version = '0.9.7-0'
+
+source = {
+  url = 'https://github.com/evandrolg/pegasus.lua.git',
+  tag = 'v0.9.7'
+}
+
+description = {
+  summary = 'Pegasus.lua is an http server to work with web applications written in Lua language.',
+  homepage = 'https://github.com/EvandroLG/pegasus.lua',
+  maintainer = 'Evandro Leopoldino Gonçalves (@evandrolg) <evandrolgoncalves@gmail.com>',
+  license = 'MIT <http://opensource.org/licenses/MIT>'
+}
+
+dependencies = {
+  "lua >= 5.1",
+  "mimetypes >= 1.0.0-1",
+  "luasocket >= 0.1.0-0",
+  "luafilesystem >= 1.6",
+  "lzlib >= 0.4.1.53-1",
+}
+
+build = {
+  type = "builtin",
+  modules = {
+    ['pegasus.init']     = "src/pegasus/init.lua",
+    ['pegasus.handler']  = 'src/pegasus/handler.lua',
+    ['pegasus.request']  = 'src/pegasus/request.lua',
+    ['pegasus.response'] = 'src/pegasus/response.lua',
+    ['pegasus.compress'] = 'src/pegasus/compress.lua'
+  }
+}

--- a/rockspecs/pegasus-0.9.7-1.rockspec
+++ b/rockspecs/pegasus-0.9.7-1.rockspec
@@ -1,0 +1,41 @@
+local package_name = "pegasus"
+local package_version = "0.9.7"
+local rockspec_revision = "1"
+local github_account_name = "evandrolg"
+local github_repo_name = "pegasus.lua"
+
+
+package = package_name
+version = package_version.."-"..rockspec_revision
+
+source = {
+  url = "git+https://github.com/"..github_account_name.."/"..github_repo_name..".git",
+  branch = (package_version == "dev") and "master" or nil,
+  tag = (package_version ~= "dev") and ("v"..package_version) or nil,
+}
+
+description = {
+  summary = 'Pegasus.lua is an http server to work with web applications written in Lua language.',
+  maintainer = 'Evandro Leopoldino Gonçalves (@evandrolg) <evandrolgoncalves@gmail.com>',
+  license = 'MIT <http://opensource.org/licenses/MIT>',
+  homepage = "https://github.com/"..github_account_name.."/"..github_repo_name,
+}
+
+dependencies = {
+  "lua >= 5.1",
+  "mimetypes >= 1.0.0-1",
+  "luasocket >= 0.1.0-0",
+  "luafilesystem >= 1.6",
+  "lzlib >= 0.4.1.53-1",
+}
+
+build = {
+  type = "builtin",
+  modules = {
+    ['pegasus.init']     = "src/pegasus/init.lua",
+    ['pegasus.handler']  = 'src/pegasus/handler.lua',
+    ['pegasus.request']  = 'src/pegasus/request.lua',
+    ['pegasus.response'] = 'src/pegasus/response.lua',
+    ['pegasus.compress'] = 'src/pegasus/compress.lua'
+  }
+}

--- a/rockspecs/pegasus-dev-1.rockspec
+++ b/rockspecs/pegasus-dev-1.rockspec
@@ -1,0 +1,41 @@
+local package_name = "pegasus"
+local package_version = "dev"
+local rockspec_revision = "1"
+local github_account_name = "evandrolg"
+local github_repo_name = "pegasus.lua"
+
+
+package = package_name
+version = package_version.."-"..rockspec_revision
+
+source = {
+  url = "git+https://github.com/"..github_account_name.."/"..github_repo_name..".git",
+  branch = (package_version == "dev") and "master" or nil,
+  tag = (package_version ~= "dev") and ("v"..package_version) or nil,
+}
+
+description = {
+  summary = 'Pegasus.lua is an http server to work with web applications written in Lua language.',
+  maintainer = 'Evandro Leopoldino Gonçalves (@evandrolg) <evandrolgoncalves@gmail.com>',
+  license = 'MIT <http://opensource.org/licenses/MIT>',
+  homepage = "https://github.com/"..github_account_name.."/"..github_repo_name,
+}
+
+dependencies = {
+  "lua >= 5.1",
+  "mimetypes >= 1.0.0-1",
+  "luasocket >= 0.1.0-0",
+  "luafilesystem >= 1.6",
+  "lzlib >= 0.4.1.53-1",
+}
+
+build = {
+  type = "builtin",
+  modules = {
+    ['pegasus.init']     = "src/pegasus/init.lua",
+    ['pegasus.handler']  = 'src/pegasus/handler.lua',
+    ['pegasus.request']  = 'src/pegasus/request.lua',
+    ['pegasus.response'] = 'src/pegasus/response.lua',
+    ['pegasus.compress'] = 'src/pegasus/compress.lua'
+  }
+}


### PR DESCRIPTION
fixes #118

Fixes several issues;

- Release 0.9.7 was missing the release rockspec in the repo.
- rockspec for 0.9.7 was bad, adds a fixed rockspec for 0.9.7-1 as replacement
- adds a "dev" rockspec to enable `luarocks make` from the repo, and as a baseline for new rockspecs

This can be merged and uploaded (no new release required);
```
luarocks upload rockspecs/pegasus-0.9.7-1.rockspec
```

Any new release; just copy the `dev` rockspec, rename it, and edit the version at the top of the file.