### PR TITLE
refactor(files) move serving files into a plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,25 @@ local server = Pegasus:new({
 server:start()
 ```
 
+
+* pegasus.plugins.files
+
+```lua
+local Pegasus = require 'pegasus'
+local Files = require 'pegasus.plugins.files'
+
+local server = Pegasus:new({
+  plugins = {
+    Files:new {
+      location = "./",
+      default = "index.html",
+    },
+  }
+})
+
+server:start()
+```
+
 * pegasus.plugins.tls
 
 ```lua

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ server:start(function (request, response)
 end)
 ```
 
+Or try the [included examples](example/README.md).
+
 ## Features
 
 - Compatible with Linux, Mac and Windows systems

--- a/example/app.lua
+++ b/example/app.lua
@@ -10,11 +10,11 @@ package.path = './src/?.lua;./src/?/init.lua;' .. package.path
 local Pegasus = require 'pegasus'
 local Compress = require 'pegasus.plugins.compress'
 local Downloads = require 'pegasus.plugins.downloads'
+local Files = require 'pegasus.plugins.files'
 -- local TLS = require 'pegasus.plugins.tls'
 
 local server = Pegasus:new({
   port = '9090',
-  location = '/example/root/',
   plugins = {
     -- TLS:new {  -- the tls specific configuration
     --   wrap = {
@@ -30,8 +30,13 @@ local server = Pegasus:new({
     -- },
 
     Downloads:new {
-      prefix = "downloads",
+      location = '/example/root/',
+      prefix = 'downloads',
       stripPrefix = true,
+    },
+
+    Files:new {
+      location = '/example/root/',
     },
 
     Compress:new(),
@@ -47,9 +52,10 @@ server:start(function(req, resp)
   end
 
   local data = req:post()
-
   if data then
-    print(data['name'])
-    print(data['age'])
+    print("Name: ", data.name)
+    print("Age: ", data.age)
   end
+  stop = not not resp:writeFile("./example/root" .. path)
+  return stop
 end)

--- a/example/app.lua
+++ b/example/app.lua
@@ -38,7 +38,14 @@ local server = Pegasus:new({
   }
 })
 
-server:start(function(req)
+server:start(function(req, resp)
+  local stop = false
+
+  local path = req:path()
+  if req:method() ~= "POST" or path ~= "/index.html" then
+    return stop
+  end
+
   local data = req:post()
 
   if data then

--- a/example/copas.lua
+++ b/example/copas.lua
@@ -20,7 +20,7 @@ local Downloads = require 'pegasus.plugins.downloads'
 -- @tparam[opt] table      opts.sslparams the tls based parameters, see the Copas documentation.
 --                         If not provided, then the connection will be accepted as a plain one.
 -- @tparam[opt] table      opts.plugins the plugins to use
--- @tparam[opt] function   opts.handler the callback function to handle requests
+-- @tparam[opt] function   opts.callback the callback function to handle requests
 -- @tparam[opt] string     opts.location the file-path from where to server files
 -- @return the server-socket on success, or nil+err on failure
 local function newPegasusServer(opts)

--- a/rockspecs/pegasus-dev-1.rockspec
+++ b/rockspecs/pegasus-dev-1.rockspec
@@ -39,6 +39,7 @@ build = {
     ['pegasus.compress'] = 'src/pegasus/compress.lua',
     ['pegasus.plugins.compress'] = 'src/pegasus/plugins/compress.lua',
     ['pegasus.plugins.downloads'] = 'src/pegasus/plugins/downloads.lua',
+    ['pegasus.plugins.files'] = 'src/pegasus/plugins/files.lua',
     ['pegasus.plugins.tls'] = 'src/pegasus/plugins/tls.lua',
   }
 }

--- a/spec/integration/integration_spec.lua
+++ b/spec/integration/integration_spec.lua
@@ -1,6 +1,6 @@
 describe('integration', function()
   local port = '7070'
-  local url = 'http://localhost:' .. port
+  local url = 'http://localhost:' .. port .. "/index.html"
 
   local executeCommand = function(command)
     local handle = assert(io.popen(command .. ' -s ' .. url))

--- a/spec/unit/files_spec.lua
+++ b/spec/unit/files_spec.lua
@@ -1,0 +1,127 @@
+describe("Files plugin", function()
+
+  local Files = require "pegasus.plugins.files"
+
+
+
+  describe("instantiation", function()
+
+    local options = {}
+    local plugin = Files:new(options)
+
+    it("should return a table", function()
+      assert.is.table(plugin)
+    end)
+
+
+    it("should have a default location; '.'", function()
+      assert.is.equal(".", plugin.location)
+    end)
+
+
+    it("should have a default; '/index.html'", function()
+      assert.is.equal("/index.html", plugin.default)
+    end)
+
+  end)
+
+
+
+  describe("invocation", function()
+
+    local redirect_called, writeFile_called
+    local request = {}
+    local response = {
+      redirect = function(self, ...) redirect_called = {...} end,
+      writeFile = function(self, ...) writeFile_called = {...} return self end,
+      -- finish = function(self, ...) end,
+      -- setHeader = function(self, ...) end,
+      -- setStatusCode = function(self, ...) end,
+    }
+
+    before_each(function()
+      redirect_called = nil
+      writeFile_called = nil
+    end)
+
+
+    it("handles GET", function()
+      stub(request, "path", function() return "/some/file.html" end)
+      stub(request, "method", function() return "GET" end)
+      local stop = Files:new():newRequestResponse(request, response)
+      assert.is.True(stop)
+      assert.is.Nil(redirect_called)
+      assert.are.same({
+        "./some/file.html",
+        "text/html"
+      }, writeFile_called)
+    end)
+
+    it("handles HEAD", function()
+      stub(request, "path", function() return "/some/file.html" end)
+      stub(request, "method", function() return "HEAD" end)
+      local stop = Files:new():newRequestResponse(request, response)
+      assert.is.True(stop)
+      assert.is.Nil(redirect_called)
+      assert.are.same({
+        "./some/file.html",
+        "text/html"
+      }, writeFile_called)
+    end)
+
+    it("doesn't handle POST", function()
+      stub(request, "path", function() return "/some/file.html" end)
+      stub(request, "method", function() return "POST" end)
+      local stop = Files:new():newRequestResponse(request, response)
+      assert.is.False(stop)
+      assert.is.Nil(redirect_called)
+      assert.is.Nil(writeFile_called)
+    end)
+
+    it("doesn't handle PUT", function()
+      stub(request, "path", function() return "/some/file.html" end)
+      stub(request, "method", function() return "PUT" end)
+      local stop = Files:new():newRequestResponse(request, response)
+      assert.is.False(stop)
+      assert.is.Nil(redirect_called)
+      assert.is.Nil(writeFile_called)
+    end)
+
+    it("redirects GET /", function()
+      stub(request, "path", function() return "/" end)
+      stub(request, "method", function() return "GET" end)
+      local stop = Files:new():newRequestResponse(request, response)
+      assert.is.True(stop)
+      assert.are.same({
+        "/index.html"
+      }, redirect_called)
+      assert.is.Nil(writeFile_called)
+    end)
+
+    it("serves from specified location", function()
+      stub(request, "path", function() return "/some/file.html" end)
+      stub(request, "method", function() return "GET" end)
+      local stop = Files:new({ location = "./location" }):newRequestResponse(request, response)
+      assert.is.True(stop)
+      assert.is.Nil(redirect_called)
+      assert.are.same({
+        "./location/some/file.html",
+        "text/html"
+      }, writeFile_called)
+    end)
+
+    it("forces location to be relative", function()
+      stub(request, "path", function() return "/some/file.html" end)
+      stub(request, "method", function() return "GET" end)
+      local stop = Files:new({ location = "/location" }):newRequestResponse(request, response)
+      assert.is.True(stop)
+      assert.is.Nil(redirect_called)
+      assert.are.same({
+        "./location/some/file.html",
+        "text/html"
+      }, writeFile_called)
+    end)
+
+  end)
+
+end)

--- a/src/pegasus/handler.lua
+++ b/src/pegasus/handler.lua
@@ -114,16 +114,16 @@ function Handler:processRequest(port, client, server)
     return false
   end
 
-  local request = Request:new(port, client, server)
-  if not request:method() then
+  local request = Request:new(port, client, server, self)
+  local response = request.response
+
+  local method = request:method()
+  if not method then
     client:close()
     return
   end
 
-  local response =  Response:new(client, self)
-  response.request = request
   local stop = self:pluginsNewRequestResponse(request, response)
-
   if stop then
     return
   end

--- a/src/pegasus/handler.lua
+++ b/src/pegasus/handler.lua
@@ -133,8 +133,10 @@ function Handler:processRequest(port, client, server)
     response.headers = {}
     response:addHeader('Content-Type', 'text/html')
 
-    self.callback(request, response)
-    return
+    stop = self.callback(request, response)
+    if stop then
+      return
+    end
   end
 
   response:writeDefaultErrorMessage(404)

--- a/src/pegasus/plugins/downloads.lua
+++ b/src/pegasus/plugins/downloads.lua
@@ -56,7 +56,9 @@ end
 
 function Downloads:newRequestResponse(request, response)
   local stop = false
-  if request:method() ~= "GET" then
+
+  local method = request:method()
+  if method ~= "GET" and method ~= "HEAD" then
     return stop -- we only handle GET requests
   end
 

--- a/src/pegasus/plugins/files.lua
+++ b/src/pegasus/plugins/files.lua
@@ -54,11 +54,12 @@ function Files:newRequestResponse(request, response)
   end
 
   local path = request:path()
-  if path == '/' or path == '' then
-    path = self.default
-    if path == "" then
-      return stop -- no default set, so nothing to serve
+  if path == '/' then
+    if self.default ~= "" then
+      response:redirect(self.default)
+      stop = true
     end
+    return stop -- no default set, so nothing to serve
   end
 
   local filename = self.location .. path

--- a/src/pegasus/plugins/files.lua
+++ b/src/pegasus/plugins/files.lua
@@ -47,7 +47,9 @@ end
 
 function Files:newRequestResponse(request, response)
   local stop = false
-  if request:method() ~= "GET" then
+
+  local method = request:method()
+  if method ~= "GET" and method ~= "HEAD" then
     return stop -- we only handle GET requests
   end
 

--- a/src/pegasus/plugins/files.lua
+++ b/src/pegasus/plugins/files.lua
@@ -1,0 +1,69 @@
+--- A plugin that serves static content from a folder.
+
+local mimetypes = require 'mimetypes'
+
+
+local Files = {}
+Files.__index = Files
+
+--- Creates a new plugin instance.
+-- The plugin will only respond to `GET` requests. The files will be served from the
+-- `location` folder.
+-- @tparam options table the options table with the following fields;
+-- @tparam[opt="./"] options.location string the path to serve files from. Relative to the working directory.
+-- @tparam[opt="index.html"] options.default string filename to serve for top-level without path. Use an empty
+-- string to have none.
+-- @return the new plugin
+function Files:new(options)
+  options = options or {}
+  local plugin = {}
+
+  local location = options.location or ""
+  if location:sub(1,2) ~= "./" then
+    if location:sub(1,1) == "/" then
+      location = "." .. location
+    else
+      location = "./" .. location
+    end
+  end
+  if location:sub(-1,-1) == "/" then
+    location = location:sub(1, -2)
+  end
+  plugin.location = location  -- this is now a relative path, without trailing slash
+
+  local default = options.default or "index.html"
+  if default ~= "" then
+    if default:sub(1,1) ~= "/" then
+      default = "/" .. default
+    end
+  end
+  plugin.default = default -- this is now a filename prefixed with a slash, or ""
+
+  setmetatable(plugin, Files)
+  return plugin
+end
+
+
+
+function Files:newRequestResponse(request, response)
+  local stop = false
+  if request:method() ~= "GET" then
+    return stop -- we only handle GET requests
+  end
+
+  local path = request:path()
+  if path == '/' or path == '' then
+    path = self.default
+    if path == "" then
+      return stop -- no default set, so nothing to serve
+    end
+  end
+
+  local filename = self.location .. path
+
+  stop = not not response:writeFile(filename, mimetypes.guess(filename) or 'text/html')
+
+  return stop
+end
+
+return Files

--- a/src/pegasus/plugins/files.lua
+++ b/src/pegasus/plugins/files.lua
@@ -20,6 +20,7 @@ function Files:new(options)
 
   local location = options.location or ""
   if location:sub(1,2) ~= "./" then
+    -- make sure it's a relative path, forcefully!
     if location:sub(1,1) == "/" then
       location = "." .. location
     else

--- a/src/pegasus/request.lua
+++ b/src/pegasus/request.lua
@@ -1,3 +1,5 @@
+local Response = require 'pegasus.response'
+
 local function normalizePath(path)
   local value = string.gsub(path ,'\\', '/')
   value = string.gsub(value, '^/*', '/')
@@ -36,7 +38,7 @@ Request.PATTERN_PATH ..Request.PATTERN_PROTOCOL)
 Request.PATTERN_QUERY_STRING = '([^=]*)=([^&]*)&?'
 Request.PATTERN_HEADER = '([%w-]+):[ \t]*([%w \t%p]*)'
 
-function Request:new(port, client, server)
+function Request:new(port, client, server, handler)
   local obj = {}
   obj.client = client
   obj.server = server
@@ -51,6 +53,8 @@ function Request:new(port, client, server)
   obj._headers = {}
   obj._contentDone = 0
   obj._contentLength = nil
+  obj.response = Response:new(client, handler)
+  obj.response.request = obj
 
   return setmetatable(obj, self)
 end
@@ -75,6 +79,7 @@ function Request:parseFirstLine()
     self.client:close()
     return
   end
+  self.response:skipBody(method == "HEAD")
 
   print('Request for: ' .. path)
 


### PR DESCRIPTION
This builds on top of #127

- moves file handling into a plugin
- enforces HEAD requests to have no body

this reduces the 'handler' to primary task of running plugins