### PR TITLE
Fix of examples

### DIFF
--- a/example/app_stream.lua
+++ b/example/app_stream.lua
@@ -18,4 +18,7 @@ server:start(function(req, res)
    sleep(3)
    res:write('c', true)
    res:close()
+
+   -- true means the callback run without error, else false or nil
+  return true
 end)

--- a/example/querystring.lua
+++ b/example/querystring.lua
@@ -16,4 +16,7 @@ end
 server:start(function (req, res)
   printTable(req['querystring'])
   res:addHeader('Content-Type', 'text/html'):write('hello pegasus world!')
+
+  -- true means the callback run without error, else false or nil
+  return true
 end)

--- a/example/write.lua
+++ b/example/write.lua
@@ -7,4 +7,7 @@ local server = Pegasus:new()
 
 server:start(function (req, res)
   res:addHeader('Content-Type', 'text/html'):write('hello pegasus world!')
+
+  -- true means the callback run without error, else false or nil
+  return true
 end)


### PR DESCRIPTION
I fixed write.lua, querystring.lua and app_stream.lua. A "return true" is mandatory in the callback, otherwith the call of processRequest will failed.