### PR TITLE
fixes: luasocket default and json library

### DIFF
--- a/example/app.lua
+++ b/example/app.lua
@@ -6,13 +6,14 @@ package.path = './src/?.lua;./src/?/init.lua;' .. package.path
 -- its examples. Copy the 'A' certificates into this example directory
 -- to make it work.
 -- Then uncomment the TLS plugin section below.
+-- Additionally you need lua-cjson to be installed.
 
 local Pegasus = require 'pegasus'
 local Compress = require 'pegasus.plugins.compress'
 local Downloads = require 'pegasus.plugins.downloads'
 local Files = require 'pegasus.plugins.files'
 local Router = require 'pegasus.plugins.router'
-local json = require 'pegasus.json'
+local json = require 'cjson.safe'
 -- local TLS = require 'pegasus.plugins.tls'
 
 

--- a/example/copas.lua
+++ b/example/copas.lua
@@ -8,6 +8,8 @@ package.path = "./src/?.lua;./src/?/init.lua;"..package.path
 -- to be installed, and you need to generate the test certificates from
 -- its examples. Copy the 'A' certificates into this example directory
 -- to make it work.
+-- Additionally you need lua-cjson to be installed.
+
 local Handler = require 'pegasus.handler'
 local copas = require('copas')
 local socket = require('socket')
@@ -15,7 +17,7 @@ local Downloads = require 'pegasus.plugins.downloads'
 local Files = require 'pegasus.plugins.files'
 local Router = require 'pegasus.plugins.router'
 local Compress = require 'pegasus.plugins.compress'
-local json = require 'pegasus.json'
+local json = require 'cjson.safe'
 
 
 --- Creates a new server within the Copas scheduler.

--- a/src/pegasus/request.lua
+++ b/src/pegasus/request.lua
@@ -65,7 +65,7 @@ function Request:parseFirstLine()
   end
 
   local status, partial
-  self._firstLine, status, partial = self.client:receive()
+  self._firstLine, status, partial = self.client:receive("*l")
 
   if (self._firstLine == nil or status == 'timeout' or partial == '' or status == 'closed') then
     return
@@ -140,7 +140,7 @@ function Request:headers()
 
   self:parseFirstLine()
 
-  local data = self.client:receive()
+  local data = self.client:receive("*l")
 
   local headers = setmetatable({},{ -- add metatable to do case-insensitive lookup
     __index = function(self, key)
@@ -167,7 +167,7 @@ function Request:headers()
       end
     end
 
-    data = self.client:receive()
+    data = self.client:receive("*l")
   end
 
   self._headerParsed = true


### PR DESCRIPTION
Some luasocket versions do not handle the "*l" default well.
By making it explicit, we can side step that failure.

also updates the examples to instruct and require lua-cjson

see #142 