### PR TITLE
chore: delete requests logs

### DIFF
--- a/src/pegasus/request.lua
+++ b/src/pegasus/request.lua
@@ -81,8 +81,6 @@ function Request:parseFirstLine()
   end
   self.response:skipBody(method == "HEAD")
 
-  print('Request for: ' .. method .. " " .. path)
-
   local filename = ''
   local querystring = ''
 


### PR DESCRIPTION
They were giving too many unnecessary messages. In my app I made custom logs and it was not nice when they were duplicated

Workaround, which I had to use to avoid duplicate logs:

```lua
print_ = print_ or print
function print(...)
	local val = tostring( select(1, ...) )
	if val:sub(1, 13) == "Request for: " then return end
	return print_(...)
end
```