### PR TITLE
fix: prevent file serving when location is empty

### DIFF
--- a/src/pegasus/handler.lua
+++ b/src/pegasus/handler.lua
@@ -11,7 +11,7 @@ function Handler:new(callback, location, plugins, logger)
   handler.callback = callback
   handler.plugins = plugins or {}
 
-  if location then
+  if location ~= '' then
     handler.plugins[#handler.plugins+1] = Files:new {
       location = location,
       default = "/index.html",


### PR DESCRIPTION
Handler:new checks if location is falsey, but in init.lua location is set to an empty string if location falsey, meaning files are served from the entire project if location is not set. 

This is my first time making a pull request, please let me know if anything's wrong.