### PR TITLE
chore(ci): fix ci bump outdated dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,11 +23,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: luarocks/gh-actions-lua@master
+      - uses: luarocks/gh-actions-lua@816ec4c55af2f6dcb9dfcba372d93dd1fb5fa8f2
         with:
           luaVersion: "5.4"
 
-      - uses: luarocks/gh-actions-luarocks@master
+      - uses: luarocks/gh-actions-luarocks@e42874645a111d78a858c3dba7530bdd707b21a4
         with:
           luaRocksVersion: "3.13.0"
 

--- a/.github/workflows/unix_build.yml
+++ b/.github/workflows/unix_build.yml
@@ -29,11 +29,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: luarocks/gh-actions-lua@master
+      - uses: luarocks/gh-actions-lua@816ec4c55af2f6dcb9dfcba372d93dd1fb5fa8f2
         with:
           luaVersion: ${{ matrix.luaVersion }}
 
-      - uses: luarocks/gh-actions-luarocks@master
+      - uses: luarocks/gh-actions-luarocks@e42874645a111d78a858c3dba7530bdd707b21a4
         with:
           luaRocksVersion: "3.13.0"
 


### PR DESCRIPTION
The tests pass on Lua 5.5. The only problem is that `luacheck` gets installed, which depends on `argparse`, which is not Lua 5.5 ready (see https://github.com/luarocks/argparse/issues/35)