### PR TITLE
Fix Unix CI dependency installation for Lua 5.5

### DIFF
--- a/.github/workflows/unix_build.yml
+++ b/.github/workflows/unix_build.yml
@@ -39,9 +39,12 @@ jobs:
 
       - name: dependencies
         run: |
-          make install
-          luarocks install luacov-coveralls
+          luarocks install mimetypes
+          luarocks install luasocket
           luarocks install busted
+          luarocks install luafilesystem
+          luarocks install lzlib
+          luarocks install luacov-coveralls
           make start_app
 
       - name: test

--- a/.github/workflows/unix_build.yml
+++ b/.github/workflows/unix_build.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           luarocks install mimetypes
           luarocks install luasocket
+          luarocks install --server=https://luarocks.org/manifests/luarocks lua-term 0.3-1
           luarocks install busted
           luarocks install luafilesystem
           luarocks install lzlib


### PR DESCRIPTION
`unix_build.yml` was calling `make install`, which installs `luacheck` as part of the full dev setup. That breaks on Lua 5.5 because `luacheck` dependencies are not available there through LuaRocks.